### PR TITLE
Track Alabama HB161 as an app-store mandate (#2)

### DIFF
--- a/LAWS.md
+++ b/LAWS.md
@@ -10,7 +10,11 @@ This document exists to show where the pressure comes from. It does not treat th
 
 ## Why legal and policy context matters
 
-The project tracks technical changes, but those changes do not arise in a vacuum. They are often driven by laws, bills, regulatory pressure, or policy agendas that attempt to push surveillance, classification, logging, or access mechanisms into general-purpose systems.
+The project tracks technical changes, but those changes do not arise in a vacuum. They are often driven by laws, bills, regulatory pressure, or policy agendas that attempt to push surveillance, classification, logging, or access mechanisms into general-purpose systems. These pressures can target different layers of the stack. This project distinguishes between:
+
+- **OS-layer mandates** that pressure general-purpose distributions (e.g., California AB-1043).
+- **App-store mandates** that pressure the mobile application ecosystem and its account layers (e.g., Alabama HB161).
+- **Client-side scanning mandates** that push for device-side inspection (e.g., EU Chat Control).
 
 A recurring pattern matters here:
 
@@ -42,6 +46,12 @@ Within the scope of this project, it reinforces the concern that these mechanism
 Brazil Lei 15.211/2025 belongs in this document because the project scope is not limited to one jurisdiction. The project is intended to document state pressure that attempts to normalize surveillance or classification mechanisms in free software distributions.
 
 As the dossier grows, this document should preserve a structured record of how each law or proposal pressures technical systems and how those pressures differ across jurisdictions.
+
+### Alabama HB161 (2026)
+
+Enacted in February 2026, Alabama HB161 requires mobile app store providers to implement age verification and parental consent systems. While its immediate target is the mobile app ecosystem (phones and tablets running mobile operating systems) rather than general-purpose Linux distributions, it is part of the same broader surveillance and control trajectory.
+
+This law matters to the project because it shows the spread of the pattern to a different technical insertion point: the app store and account layer. Key provisions include requiring app stores to verify a user's age category using commercially available systems and to obtain verifiable parental consent for minors. This establishes a precedent for building verification and gating systems directly into software distribution channels.
 
 ### EU Chat Control and related policy pushes
 

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -34,6 +34,7 @@ The tracker uses the following labels.
 | Ubuntu desktop provisioning | [canonical/ubuntu-desktop-provision](https://github.com/canonical/ubuntu-desktop-provision) | [PR #1339](https://github.com/canonical/ubuntu-desktop-provision/pull/1339) | draft | Writes `BirthDate` into target AccountsService data during installation | Extends the downstream integration into persisted account metadata |
 | Archinstall | [archlinux/archinstall](https://github.com/archlinux/archinstall) | [PR #4290](https://github.com/archlinux/archinstall/pull/4290) | active implementation | Adds a required birth date field during user creation and writes it into userdb | Demonstrates installer-level normalization in a major distro tool |
 | AccountsService | [accountsservice/accountsservice](https://gitlab.freedesktop.org/accountsservice/accountsservice) | [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176) | discussion | Referenced by related work as a storage and D-Bus layer for `BirthDate` | Represents a likely account metadata layer in the wider stack |
+| Mobile App Ecosystem | N/A (Legislation) | [Alabama HB161 (2026)](https://legiscan.com/AL/bill/HB161/2026) | watchlist | Policy driver for verification/gating in app stores; shows pattern spreading to ecosystem layer | Establishes precedent for distribution-channel mandates, though not currently impacting Linux stack |
 
 ## Primary source links
 


### PR DESCRIPTION
Extend the legal and policy map to distinguish between different                                                                                                                                                                                                                   insertion points for surveillance and control mechanisms:
                                                                                                                                                                                                                                                                                   - OS-layer mandates
- app-store mandates                                                                                                                                                                                                                                                               - client-side scanning mandates
                                                                                                                                                                                                                                                                                   Add Alabama HB161 to LAWS.md as an example of pressure applied at the
mobile app store and account layer rather than directly at the
general-purpose OS layer.

Add a watchlist entry to TRACKER.md so the project records the spread of verification and gating mandates beyond the current Linux-stack targets, without conflating that policy driver with an active Linux implementation component.