### PR TITLE
docs: expand legal taxonomy and refactor multi-layer policy tracking (#8)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,15 @@ Whenever possible, use the direct primary source:
 
 Do not leave a named tracked item unlinked when the direct source exists.
 
+### Legal and policy source standards
+
+For policy-driver entries in [LAWS.md](LAWS.md) or [TRACKER.md](TRACKER.md), use official primary sources wherever practical. The link text must accurately label the source.
+
+- **Preferred:** Official legislature bill pages, enrolled bill PDFs, or official fiscal notes. Label these accurately (e.g., "Official bill text").
+- **Acceptable:** Legislative trackers such as LegiScan may be included as supplementary links, but should not be the only source when an official source is available. Label these truthfully (e.g., "LegiScan").
+
+Policy items added to the tracker must include the bill name and jurisdiction, the technical layer targeted (e.g., OS-layer, App-store layer), current legislative status, and a direct primary source link.
+
 ## Linking standards
 
 Use direct Markdown links to primary sources wherever possible.

--- a/LAWS.md
+++ b/LAWS.md
@@ -25,35 +25,75 @@ A recurring pattern matters here:
 
 This project rejects that framing. The point of documenting the policy layer is not to help design cleaner compliance. It is to explain the pressure pathway and make the normalization attempt legible.
 
-## Current legal and policy drivers
+## U.S. state landscape
 
-### California AB-1043
+The legal pressure in the United States is not an isolated phenomenon. It represents a set of parallel experiments in pushing age verification, classification, parental-consent infrastructure, or disclosure obligations into different layers of the software stack.
 
-California AB-1043 is a central trigger for current Linux-stack implementation discussions around OS-level age verification and age signaling. Public discussions around provisioning, user records, account metadata, and app-facing APIs have repeatedly cited this law as a compliance driver.
+### OS-layer mandates
 
-Within the scope of this project, AB-1043 matters because it pressures operating-system-level components toward collecting and exposing age-related data for application or service use.
+These laws or proposals target the operating system itself, pressuring distributions to build in functionality for account-setup age collection and to provide a real-time API or signal for applications to consume.
 
-The core concern is not only the law’s text, but the implementation frame it creates. Once projects begin debating where to store the data, how to expose it, or how to package it, the discussion has already shifted away from the more important question of whether such a mechanism should exist at all.
+#### California AB-1043
 
-### Colorado SB26-051
+California AB-1043 is a central trigger for current Linux-stack implementation discussions around OS-level age verification and age signaling. Public discussions around provisioning, user records, account metadata, and app-facing APIs have repeatedly cited this law as a compliance driver. ([Official bill text](https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202520260AB1043))
 
-Colorado SB26-051 is closely associated with the same implementation pressure. It appears alongside California AB-1043 in current discussions as a parallel driver for age-related account and API work.
+Within the scope of this project, AB-1043 matters because it pressures operating-system-level components toward collecting and exposing age-related data for application or service use. The core concern is not only the law’s text, but the implementation frame it creates. Once projects begin debating where to store the data, how to expose it, or how to package it, the discussion has already shifted away from the more important question of whether such a mechanism should exist at all.
+
+#### Colorado SB 26-051
+
+Colorado SB26-051 is closely associated with the same implementation pressure. It follows the OS-layer age-attestation model and appears alongside California AB-1043 in current discussions as a parallel driver for age-related account and API work. ([Official bill page](https://leg.colorado.gov/bills/sb26-051))
 
 Within the scope of this project, it reinforces the concern that these mechanisms are not being proposed as isolated experiments, but as responses to a growing compliance pattern. That pattern matters because it encourages projects to think in terms of implementation pathways rather than categorical refusal.
 
+### App-store mandates
+
+These laws target the application distribution layer, pressuring app-store providers, account systems, and developers to implement age verification, parental consent mechanisms, and age-gating for content and downloads. They represent a different technical insertion point but are part of the same broader surveillance and control trajectory.
+
+#### Alabama HB 161
+
+Enacted in February 2026, Alabama HB161 requires mobile app store providers to implement age verification and parental consent systems. While its immediate target is the mobile app ecosystem, it is part of the same family of pressure. ([LegiScan](https://legiscan.com/AL/text/HB161/id/3357012))
+
+This law matters to the project because it shows the spread of the pattern to the app store and account layer. Key provisions include requiring app stores to verify a user's age category and obtain verifiable parental consent for minors, establishing a precedent for building verification and gating systems directly into software distribution channels.
+
+#### Louisiana HB 570 / Act 481
+
+This enacted Louisiana law regulates app stores and developers around minors’ app use, age-category data, and parental consent. ([Official bill page](https://www.legis.la.gov/Legis/BillInfo.aspx?i=248616))
+
+Like the Alabama law, it demonstrates how the policy pressure is expanding to control the application distribution layer, reinforcing the need for this project to track mandates beyond the core operating system.
+
+#### Utah HB 498
+
+This bill amends Utah's App Store Accountability Act, adding requirements around pre-installed applications and app-store/provider duties in the same family of measures. ([Official enrolled bill](https://le.utah.gov/Session/2026/bills/enrolled/HB0498.pdf))
+
+Its relevance is in showing the iterative tightening of app-store-layer regulation, confirming this as a durable and evolving pressure point.
+
+#### Texas SB 2420
+
+Texas enacted this app-store accountability model, but its enforcement was preliminarily blocked by a federal court. ([Official bill text](https://capitol.texas.gov/tlodocs/89R/billtext/pdf/SB02420E.pdf), [Reuters](https://www.reuters.com/legal/government/us-judge-blocks-texas-app-store-age-law-meant-protect-children-2025-12-23/))
+
+It belongs in the dossier as an example of both the legislative spread and the potential for legal challenges to interrupt enforcement.
+
+#### Florida SB 1722
+
+This filed bill is an example of the App Store Accountability Act model, requiring app-store age verification, parent-linked minor accounts, and parental consent. ([Official bill page](https://www.flsenate.gov/Session/Bill/2026/1722))
+
+It serves as evidence that the app-store mandate model is not contained to a few states but is an active template for new legislation.
+
+#### Arizona HB 2920
+
+This introduced bill uses the same app-store age category data, parental consent, and developer duties model seen in other states. ([Official bill text](https://www.azleg.gov/legtext/57leg/2R/bills/hb2920p.pdf))
+
+Its presence in the dossier confirms the geographic spread and persistence of this legislative pattern.
+
+## Other jurisdictions
+
 ### Brazil Lei 15.211/2025
 
-Brazil Lei 15.211/2025 belongs in this document because the project scope is not limited to one jurisdiction. The project is intended to document state pressure that attempts to normalize surveillance or classification mechanisms in free software distributions.
+Brazil Lei 15.211/2025 belongs in this document because the project scope is not limited to one jurisdiction. The project is intended to document state pressure that attempts to normalize surveillance or classification mechanisms in free software distributions, wherever it appears.
 
-As the dossier grows, this document should preserve a structured record of how each law or proposal pressures technical systems and how those pressures differ across jurisdictions.
+As the dossier grows, this document must preserve a structured record of how different laws or proposals pressure technical systems and how those pressures differ across jurisdictions. This ensures the project remains a global resource, not a U.S.-centric one.
 
-### Alabama HB161 (2026)
-
-Enacted in February 2026, Alabama HB161 requires mobile app store providers to implement age verification and parental consent systems. While its immediate target is the mobile app ecosystem (phones and tablets running mobile operating systems) rather than general-purpose Linux distributions, it is part of the same broader surveillance and control trajectory.
-
-This law matters to the project because it shows the spread of the pattern to a different technical insertion point: the app store and account layer. Key provisions include requiring app stores to verify a user's age category using commercially available systems and to obtain verifiable parental consent for minors. This establishes a precedent for building verification and gating systems directly into software distribution channels.
-
-### EU Chat Control and related policy pushes
+## EU Chat Control and related policy pushes
 
 The broader policy context includes EU Chat Control and related "lawful-access" initiatives. These are important to this project because they show a recurring pattern: child-safety or law-enforcement rhetoric is used to normalize technical mechanisms for inspection, classification, access, or logging.
 

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -10,7 +10,7 @@ This project exists because a line is being crossed.
 
 That line is crossed when free software distributions are pressured to collect age-related data at installation or provisioning time. It is crossed when account metadata services are repurposed to store that data. It is crossed when portals and standard APIs are designed to expose it. It is crossed when application and service ecosystems begin assuming that the operating system should provide user classification as a normal function.
 
-We reject that entire category of change.
+We reject that entire category of change. The pressure now arrives through multiple technical layers, including OS-layer age-signal mandates, app-store age-verification mandates, and client-side scanning or "lawful-access" pushes. They are all part of the same unacceptable trajectory.
 
 ## What we reject
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The immediate concern is not one isolated patch. The concern is an architectural
 - a portal or standard API exposes it
 - applications, app stores, or services consume it
 
-The same broader pattern also appears in other policy pushes, including client-side scanning and related "lawful-access" initiatives. The underlying problem is the same: technical pressure to normalize surveillance or classification mechanisms inside user systems.
+The same broader pattern also appears in other policy pushes, including client-side scanning and related "lawful-access" initiatives. The underlying problem is the same: technical pressure to normalize surveillance or classification mechanisms inside user systems. That pressure now arrives through multiple legislative insertion points, including OS-layer mandates, app-store-layer mandates, and client-side scanning pushes.
 
 See [Current Repository Targets](REPO-TARGETS.md), [Technical Architecture](STACK.md), and [Laws and Policy Drivers](LAWS.md).
 
@@ -113,6 +113,7 @@ The highest current priorities are:
 - track and oppose standardization in portal and metadata layers
 - track and oppose normalization in core account and user record services
 - maintain a public record of downstream integration work
+- expand the legal map to track the spread of OS-layer and app-store-layer mandates across U.S. states
 - prepare downstream removal and package-level stripping strategies if upstream merges occur
 - keep the project precise, linkable, and easy to audit
 

--- a/REPO-TARGETS.md
+++ b/REPO-TARGETS.md
@@ -4,7 +4,7 @@ Back to the front page: [README.md](README.md)
 
 ## Purpose
 
-This document lists the current technical targets in scope and explains why each matters within the Linux stack.
+This document lists the current technical targets in scope and explains why each matters within the Linux stack. These targets are often linked to broader legal drivers which are mapped in detail in [LAWS.md](LAWS.md).
 
 For live status, pull requests, and issues, see [TRACKER.md](TRACKER.md). For the stack model, see [STACK.md](STACK.md).
 

--- a/STACK.md
+++ b/STACK.md
@@ -19,6 +19,19 @@ Applications, app stores, or services
 
 This path matters because a surveillance mechanism does not need to appear in one dramatic component to become real. It can spread incrementally across several layers until the overall system functions as a policy-enforcement endpoint.
 
+## Regulatory insertion points
+
+Different laws and policy proposals target different layers of the technology stack. The project tracks these together because they all push toward classification, verification, gating, inspection, or control, but it is important to distinguish the technical insertion points.
+
+- **OS layer**
+  This includes provisioning flows, account metadata services, user records, and operating-system-level APIs. Mandates at this layer pressure the core distribution.
+
+- **App-store layer**
+  This includes store accounts, parental-consent infrastructure, developer-facing age/consent data, and the software distribution channel itself.
+
+- **Service / app-consumption layer**
+  This includes application-side enforcement, download gating, and launch-time age handling by individual applications that consume data from the layers above.
+
 ## Layer-by-layer explanation
 
 ### 1. Installer or provisioning flow

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -6,7 +6,7 @@ Back to the front page: [README.md](README.md)
 
 This document is the operational evidence index for OSS Anti Surveillance.
 
-It records the currently known components, repositories, issues, pull requests, merge requests, status, and why each item matters. It is the main working index for current implementation activity.
+It records the currently known components, repositories, issues, pull requests, merge requests, status, and why each item matters. It is the main working index for current implementation activity. Policy-driver entries are included as a watchlist to provide context for technical work but are not automatically active Linux implementation targets.
 
 For legal and policy background, see [LAWS.md](LAWS.md). For the architecture map, see [STACK.md](STACK.md). For component descriptions, see [REPO-TARGETS.md](REPO-TARGETS.md). For removal strategy, see [REVERSIONS/README.md](REVERSIONS/README.md).
 
@@ -26,6 +26,8 @@ The tracker uses the following labels.
 
 ## Current evidence index
 
+### Active Linux implementation targets
+
 | Component | Repository | Item | Status | Why it matters | Downstream implications |
 | --- | --- | --- | --- | --- | --- |
 | systemd | [systemd/systemd](https://github.com/systemd/systemd) | [PR #40954](https://github.com/systemd/systemd/pull/40954) | active implementation | Adds `birthDate` to JSON user records for age-verification-related use, normalizing age-related metadata in a core userdb path | Creates a core storage substrate that downstreams may consume or inherit |
@@ -35,11 +37,23 @@ The tracker uses the following labels.
 | Ubuntu desktop provisioning | [canonical/ubuntu-desktop-provision](https://github.com/canonical/ubuntu-desktop-provision) | [PR #1339](https://github.com/canonical/ubuntu-desktop-provision/pull/1339) | closed unmerged | Closed unmerged after public objections and internal review | Demonstrates that downstream integration is not inevitable and can be halted before merge |
 | Archinstall | [archlinux/archinstall](https://github.com/archlinux/archinstall) | [PR #4290](https://github.com/archlinux/archinstall/pull/4290) | active implementation | Adds a required birth date field during user creation and writes it into userdb | Demonstrates installer-level normalization in a major distro tool |
 | AccountsService | [accountsservice/accountsservice](https://gitlab.freedesktop.org/accountsservice/accountsservice) | [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176) | discussion | Referenced by related work as a storage and D-Bus layer for `BirthDate` | Represents a likely account metadata layer in the wider stack |
-| Mobile App Ecosystem | N/A (Legislation) | [Alabama HB161 (2026)](https://legiscan.com/AL/bill/HB161/2026) | watchlist | Policy driver for verification/gating in app stores; shows pattern spreading to ecosystem layer | Establishes precedent for distribution-channel mandates, though not currently impacting Linux stack |
 
-## Primary source links
+### Policy drivers and legal watchlist
 
-These are the primary upstream items currently tracked in this project:
+| Layer | Jurisdiction / Bill | Status | Why it matters | Downstream implications |
+| --- | --- | --- | --- | --- |
+| OS-layer | [California AB 1043](https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202520260AB1043) | watchlist | Direct OS-layer mandate relevant to Linux distribution architecture | Key driver for current implementation work in systemd and desktop portals |
+| OS-layer | [Colorado SB 26-051](https://leg.colorado.gov/bills/sb26-051) | watchlist | Follows the same OS-layer age-attestation and signaling model as CA | Reinforces the compliance pattern driving OS-level technical changes |
+| App-store | [Alabama HB 161](https://legiscan.com/AL/text/HB161/id/3357012) | watchlist | Enacted law showing the pattern spreading to the app-store distribution layer | Establishes precedent for distribution-channel mandates, though not yet a Linux target |
+| App-store | [Louisiana HB 570 / Act 481](https://www.legis.la.gov/Legis/BillInfo.aspx?i=248616) | watchlist | Enacted law targeting app stores, reinforcing the app-store layer pattern | Not currently a Linux OS implementation target |
+| App-store | [Utah HB 498](https://le.utah.gov/Session/2026/bills/enrolled/HB0498.pdf) | watchlist | App-store accountability model | Not currently a Linux OS implementation target |
+| App-store | [Texas SB 2420](https://capitol.texas.gov/tlodocs/89R/billtext/pdf/SB02420E.pdf) | watchlist | Enacted but blocked; app-store model | Not currently a Linux OS implementation target |
+| App-store | [Florida SB 1722](https://www.flsenate.gov/Session/Bill/2026/1722) | watchlist | App-store accountability model | Not currently a Linux OS implementation target |
+| App-store | [Arizona HB 2920](https://www.azleg.gov/legtext/57leg/2R/bills/hb2920p.pdf) | watchlist | App-store accountability model | Not currently a Linux OS implementation target |
+
+## Primary tracked sources
+
+### Active Linux implementation targets
 
 - [systemd PR #40954](https://github.com/systemd/systemd/pull/40954)
 - [systemd Issue #40974](https://github.com/systemd/systemd/issues/40974)
@@ -48,6 +62,17 @@ These are the primary upstream items currently tracked in this project:
 - [ubuntu-desktop-provision PR #1339](https://github.com/canonical/ubuntu-desktop-provision/pull/1339)
 - [Archinstall PR #4290](https://github.com/archlinux/archinstall/pull/4290)
 - [AccountsService MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176)
+
+### Policy drivers and legal watchlist
+
+- [California AB 1043](https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202520260AB1043)
+- [Colorado SB 26-051](https://leg.colorado.gov/bills/sb26-051)
+- [Alabama HB 161](https://legiscan.com/AL/text/HB161/id/3357012)
+- [Louisiana HB 570 / Act 481](https://www.legis.la.gov/Legis/BillInfo.aspx?i=248616)
+- [Utah HB 498](https://le.utah.gov/Session/2026/bills/enrolled/HB0498.pdf)
+- [Texas SB 2420](https://capitol.texas.gov/tlodocs/89R/billtext/pdf/SB02420E.pdf)
+- [Florida SB 1722](https://www.flsenate.gov/Session/Bill/2026/1722)
+- [Arizona HB 2920](https://www.azleg.gov/legtext/57leg/2R/bills/hb2920p.pdf)
 
 ## Immediate observations
 


### PR DESCRIPTION
This change expands the project's documentation to provide a comprehensive,
multi-layer legal taxonomy for U.S. state-level age verification and
app-store control laws.

LAWS.md is restructured to introduce a U.S. state landscape section with
explicit OS-layer and app-store subsections, covering eight state laws
across two legislative models. Each entry uses a two-paragraph narrative
format. Global scope is preserved under a dedicated Other Jurisdictions
section. All legislative source links use accurate labels.

TRACKER.md is refactored into two separate, clearly-headed tables —
one for active Linux implementation targets, one for policy drivers and
the legal watchlist — improving at-a-glance readability and preventing
conflation of code targets with monitored legislation.

CONTRIBUTING.md is updated to require official primary legislative sources
and truthful link labeling for all policy-driver entries, bolstering the
project's evidentiary rigor.

README.md, MANIFESTO.md, and REPO-TARGETS.md receive minimal alignment
text acknowledging the multi-layer nature of the policy pressure.