### PR TITLE
docs: track elementary OS and refactor component categories (#10)

### DIFF
--- a/REPO-TARGETS.md
+++ b/REPO-TARGETS.md
@@ -10,7 +10,9 @@ For live status, pull requests, and issues, see [TRACKER.md](TRACKER.md). For th
 
 ## Current targets
 
-### systemd
+### Shared infrastructure targets
+
+#### systemd
 
 Repository: [systemd/systemd](https://github.com/systemd/systemd)
 
@@ -23,7 +25,7 @@ Current upstream references:
 - [PR #40954](https://github.com/systemd/systemd/pull/40954)
 - [Issue #40974](https://github.com/systemd/systemd/issues/40974)
 
-### xdg-desktop-portal
+#### xdg-desktop-portal
 
 Repository: [flatpak/xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal)
 
@@ -35,7 +37,7 @@ Current upstream references:
 
 - [PR #1922](https://github.com/flatpak/xdg-desktop-portal/pull/1922)
 
-### AccountsService
+#### AccountsService
 
 Repository: [accountsservice/accountsservice](https://gitlab.freedesktop.org/accountsservice/accountsservice)
 
@@ -47,7 +49,9 @@ Current upstream references:
 
 - [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176)
 
-### Ubuntu desktop provisioning
+### Distribution / desktop integration targets
+
+#### Ubuntu desktop provisioning
 
 Repository: [canonical/ubuntu-desktop-provision](https://github.com/canonical/ubuntu-desktop-provision)
 
@@ -60,7 +64,7 @@ Current upstream references:
 - [PR #1338](https://github.com/canonical/ubuntu-desktop-provision/pull/1338)
 - [PR #1339](https://github.com/canonical/ubuntu-desktop-provision/pull/1339)
 
-### Archinstall
+#### Archinstall
 
 Repository: [archlinux/archinstall](https://github.com/archlinux/archinstall)
 
@@ -71,6 +75,32 @@ Why it matters: it shows that the collection and storage step can be pushed dire
 Current upstream references:
 
 - [PR #4290](https://github.com/archlinux/archinstall/pull/4290)
+
+#### elementary/settings-useraccounts
+
+Repository: [elementary/settings-useraccounts](https://github.com/elementary/settings-useraccounts)
+
+Role in the stack: This component is relevant because it sits in the desktop account-management and user-declaration layer. It is a direct integration point for UI related to age collection during account setup.
+
+Why it matters: This shows the surveillance and classification pattern spreading to another desktop-specific ecosystem, demonstrating that the pressure is not isolated to one or two distributions.
+
+Current upstream references:
+
+- [Issue #260](https://github.com/elementary/settings-useraccounts/issues/260)
+- [PR #270](https://github.com/elementary/settings-useraccounts/pull/270)
+
+#### elementary/portals
+
+Repository: [elementary/portals](https://github.com/elementary/portals)
+
+Role in the stack: This component is relevant because it provides a desktop-specific portal and user-information exposure layer. It can act as the bridge between stored user data and applications that consume it.
+
+Why it matters: This shows a desktop-specific implementation of the portal layer, which is a critical part of the architectural propagation path for normalizing surveillance mechanisms.
+
+Current upstream references:
+
+- [Issue #173](https://github.com/elementary/portals/issues/173)
+- [PR #180](https://github.com/elementary/portals/pull/180)
 
 ## Watchlist concept
 

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -28,15 +28,26 @@ The tracker uses the following labels.
 
 ### Active Linux implementation targets
 
+#### Shared upstream / common infrastructure
+
 | Component | Repository | Item | Status | Why it matters | Downstream implications |
 | --- | --- | --- | --- | --- | --- |
 | systemd | [systemd/systemd](https://github.com/systemd/systemd) | [PR #40954](https://github.com/systemd/systemd/pull/40954) | active implementation | Adds `birthDate` to JSON user records for age-verification-related use, normalizing age-related metadata in a core userdb path | Creates a core storage substrate that downstreams may consume or inherit |
 | systemd | [systemd/systemd](https://github.com/systemd/systemd) | [Issue #40974](https://github.com/systemd/systemd/issues/40974) | closed unmerged | Closed as not planned; maintainers indicated birthDate remains preferred and ageGroup should live elsewhere via a service | Rejects one schema variant in systemd userdb, but leaves the broader service-based age-verification path open |
 | xdg-desktop-portal | [flatpak/xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal) | [PR #1922](https://github.com/flatpak/xdg-desktop-portal/pull/1922) | draft | App-facing portal/API normalization point for age-related querying | Makes the mechanism easier to standardize across desktop environments and applications |
+| AccountsService | [accountsservice/accountsservice](https://gitlab.freedesktop.org/accountsservice/accountsservice) | [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176) | discussion | Referenced by related work as a storage and D-Bus layer for `BirthDate` | Represents a likely account metadata layer in the wider stack |
+
+#### Distribution / desktop-specific integrations
+
+| Component | Repository | Item | Status | Why it matters | Downstream implications |
+| --- | --- | --- | --- | --- | --- |
 | Ubuntu desktop provisioning | [canonical/ubuntu-desktop-provision](https://github.com/canonical/ubuntu-desktop-provision) | [PR #1338](https://github.com/canonical/ubuntu-desktop-provision/pull/1338) | closed unmerged | Closed unmerged after discussion; linked to the related implementation path in #1339 | Shows that implementation paths can be interrupted before merge |
 | Ubuntu desktop provisioning | [canonical/ubuntu-desktop-provision](https://github.com/canonical/ubuntu-desktop-provision) | [PR #1339](https://github.com/canonical/ubuntu-desktop-provision/pull/1339) | closed unmerged | Closed unmerged after public objections and internal review | Demonstrates that downstream integration is not inevitable and can be halted before merge |
 | Archinstall | [archlinux/archinstall](https://github.com/archlinux/archinstall) | [PR #4290](https://github.com/archlinux/archinstall/pull/4290) | active implementation | Adds a required birth date field during user creation and writes it into userdb | Demonstrates installer-level normalization in a major distro tool |
-| AccountsService | [accountsservice/accountsservice](https://gitlab.freedesktop.org/accountsservice/accountsservice) | [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176) | discussion | Referenced by related work as a storage and D-Bus layer for `BirthDate` | Represents a likely account metadata layer in the wider stack |
+| elementary settings-useraccounts | [elementary/settings-useraccounts](https://github.com/elementary/settings-useraccounts) | [Issue #260](https://github.com/elementary/settings-useraccounts/issues/260) | discussion | Explicitly frames age-related account setup work as California-law compliance | Shows pressure reaching desktop account-management UI |
+| elementary settings-useraccounts | [elementary/settings-useraccounts](https://github.com/elementary/settings-useraccounts) | [PR #270](https://github.com/elementary/settings-useraccounts/pull/270) | draft | Implements age declaration UI in a desktop account-management component | Demonstrates distro/desktop integration of age declaration concepts |
+| elementary portals | [elementary/portals](https://github.com/elementary/portals) | [Issue #173](https://github.com/elementary/portals/issues/173) | discussion | Proposes account portal work in a user-information exposure layer | Creates a portal-level integration point in elementary OS |
+| elementary portals | [elementary/portals](https://github.com/elementary/portals) | [PR #180](https://github.com/elementary/portals/pull/180) | active implementation | Open multi-commit implementation of the account portal linked to issue #173 | Shows live portal-layer work in a desktop-specific integration path |
 
 ### Policy drivers and legal watchlist
 
@@ -62,6 +73,11 @@ The tracker uses the following labels.
 - [ubuntu-desktop-provision PR #1339](https://github.com/canonical/ubuntu-desktop-provision/pull/1339)
 - [Archinstall PR #4290](https://github.com/archlinux/archinstall/pull/4290)
 - [AccountsService MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176)
+- [elementary/settings-useraccounts Issue #260](https://github.com/elementary/settings-useraccounts/issues/260)
+- [elementary/settings-useraccounts PR #270](https://github.com/elementary/settings-useraccounts/pull/270)
+- [elementary/portals Issue #173](https://github.com/elementary/portals/issues/173)
+- [elementary/portals PR #180](https://github.com/elementary/portals/pull/180)
+
 
 ### Policy drivers and legal watchlist
 


### PR DESCRIPTION
Incorporates new findings from the elementary OS ecosystem into the project's evidence tracker, specifically from the `settings-useraccounts` and `portals` repositories. This provides additional evidence of the surveillance and classification pattern spreading to desktop-specific integration layers.

To improve architectural clarity, this change also refactors both `TRACKER.md` and `REPO-TARGETS.md`. Technical components are now categorized into two distinct groups:
- Shared Upstream Infrastructure (e.g., systemd, AccountsService)
- Distribution / Desktop Integrations (e.g., Archinstall, elementary)

This new structure makes the propagation path of surveillance mechanisms— from foundational upstream components to downstream consumer integrations—more explicit and easier for readers to analyze.