### PR TITLE
docs: expand tracking to include BSD and new implementation vectors (#14)

### DIFF
--- a/REPO-TARGETS.md
+++ b/REPO-TARGETS.md
@@ -4,13 +4,13 @@ Back to the front page: [README.md](README.md)
 
 ## Purpose
 
-This document lists the current technical targets in scope and explains why each matters within the Linux stack. These targets are often linked to broader legal drivers which are mapped in detail in [LAWS.md](LAWS.md).
+This document lists the current technical targets in scope and explains why each matters. These targets are often linked to broader legal drivers which are mapped in detail in [LAWS.md](LAWS.md). It now tracks both Linux-centered implementation targets and broader free Unix-like integration paths where the same surveillance architecture is being proposed.
 
 For live status, pull requests, and issues, see [TRACKER.md](TRACKER.md). For the stack model, see [STACK.md](STACK.md).
 
 ## Current targets
 
-### Shared infrastructure targets
+### Linux: Shared infrastructure targets
 
 #### systemd
 
@@ -49,19 +49,7 @@ Current upstream references:
 
 - [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176)
 
-#### ageverifyd
-
-Repository: [outerheaven199X/ageverifyd](https://github.com/outerheaven199X/ageverifyd)
-
-Role in the stack: ageverifyd acts as a reference implementation of a standalone OS-level daemon for age verification and bracket storage.
-
-Why it matters: It demonstrates that the architecture is moving beyond theoretical discussion into ready-to-use plumbing (implementing `org.freedesktop.AgeVerification1`), designed specifically to help distributions and app stores comply with legislative mandates like California AB-1043.
-
-Current upstream references:
-
-- [Repository README](https://github.com/outerheaven199X/ageverifyd)
-
-### Distribution / desktop integration targets
+### Linux: Distribution / desktop integration targets
 
 #### Ubuntu desktop provisioning
 
@@ -113,6 +101,35 @@ Current upstream references:
 
 - [Issue #173](https://github.com/elementary/portals/issues/173)
 - [PR #180](https://github.com/elementary/portals/pull/180)
+
+### Reference implementations / prototypes
+
+#### ageverifyd
+
+Repository: [outerheaven199X/ageverifyd](https://github.com/outerheaven199X/ageverifyd)
+
+Role in the stack: ageverifyd acts as a reference implementation of a standalone OS-level daemon for age verification and bracket storage.
+
+Why it matters: It demonstrates that the architecture is moving beyond theoretical discussion into ready-to-use plumbing (implementing `org.freedesktop.AgeVerification1`), designed specifically to help distributions and app stores comply with legislative mandates like California AB-1043.
+
+Current upstream references:
+
+- [Repository README](https://github.com/outerheaven199X/ageverifyd)
+
+### BSD / Unix-like integration targets
+
+#### MidnightBSD age verification
+
+Repository: [MidnightBSD Project](https://www.midnightbsd.org/)
+
+Role in the stack: This work represents a complete, parallel implementation of an OS-level age verification architecture for a BSD-based operating system. It includes installer (`bsdinstall`) and user management (`adduser`) integration, dedicated helper tools (`aged`, `agectl`), and enforcement paths via the package manager (`mport`) and ACLs.
+
+Why it matters: This is critical evidence that the surveillance architecture is not a Linux-specific problem. It is a pattern spreading to other free Unix-like operating systems, using native system administration tools and concepts.
+
+Current upstream references:
+
+- [Implementation Draft](https://docs.google.com/document/d/1_NKq0bpN1pOrMpHePuilJY7saXqXqhss6LwPTC6nSto/edit)
+- [Mailing list discussion](https://lists.freedesktop.org/archives/xdg/2026-March/014777.html)
 
 ## Watchlist concept
 

--- a/STACK.md
+++ b/STACK.md
@@ -4,20 +4,25 @@ Back to the front page: [README.md](README.md)
 
 ## Purpose
 
-This document describes the architecture path through which surveillance, classification, or policy-enforcement mechanisms can propagate across a Linux distribution stack.
+This document describes the architecture path through which surveillance, classification, or policy-enforcement mechanisms can propagate across a free software distribution stack.
 
 For the live evidence index, see [TRACKER.md](TRACKER.md). For component-specific descriptions, see [REPO-TARGETS.md](REPO-TARGETS.md).
 
 ## Core propagation path
 
-The currently visible path is:
+The currently visible implementation efforts are not monolithic. They represent a branching set of strategies for embedding age classification into OS-level architecture. A surveillance mechanism can spread incrementally across several layers until the overall system functions as a policy-enforcement endpoint.
 
-Installer or provisioning flow
-Account metadata service or user record storage
-Portal or standard application-facing API
-Applications, app stores, or services
+The key architectural layers and proposed vectors now include:
 
-This path matters because a surveillance mechanism does not need to appear in one dramatic component to become real. It can spread incrementally across several layers until the overall system functions as a policy-enforcement endpoint.
+- **Installer / Account-creation flow:** The point of initial data collection (e.g., `bsdinstall`, `Archinstall`, Ubuntu provisioning).
+- **Account metadata / Age storage:** The persistence layer for user age or date of birth (e.g., systemd userdb, AccountsService, or custom `/etc` files).
+- **Daemon / Helper layer:** Standalone services for managing and exposing age data (e.g., `ageverifyd`, `aged`).
+- **Portal / D-Bus / API:** The application-facing interface for querying age status (e.g., `xdg-desktop-portal`).
+- **Package manager / Repository integration:** Using the package manager to gate access to software based on age ratings (e.g., MidnightBSD `mport` proposal).
+- **Filesystem / ACL / LSM enforcement:** Lower-level proposals for enforcing access control based on age, using mechanisms like extended attributes (xattrs), Access Control Lists (ACLs), or Linux Security Modules (LSMs).
+- **File-based attestation:** Proposals for using root-owned files on the filesystem to signal age brackets, as an alternative to a D-Bus service.
+
+This path matters because it shows the problem is not a single API but a system-wide architectural shift being explored across multiple components and operating systems.
 
 ## Regulatory insertion points
 

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -26,7 +26,7 @@ The tracker uses the following labels.
 
 ## Current evidence index
 
-### Active Linux implementation targets
+### Linux implementation targets
 
 #### Shared upstream / common infrastructure
 
@@ -36,7 +36,6 @@ The tracker uses the following labels.
 | systemd | [systemd/systemd](https://github.com/systemd/systemd) | [Issue #40974](https://github.com/systemd/systemd/issues/40974) | closed unmerged | Closed as not planned; maintainers indicated birthDate remains preferred and ageGroup should live elsewhere via a service | Rejects one schema variant in systemd userdb, but leaves the broader service-based age-verification path open |
 | xdg-desktop-portal | [flatpak/xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal) | [PR #1922](https://github.com/flatpak/xdg-desktop-portal/pull/1922) | draft | App-facing portal/API normalization point for age-related querying | Makes the mechanism easier to standardize across desktop environments and applications |
 | AccountsService | [accountsservice/accountsservice](https://gitlab.freedesktop.org/accountsservice/accountsservice) | [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176) | discussion | Referenced by related work as a storage and D-Bus layer for `BirthDate` | Represents a likely account metadata layer in the wider stack |
-| ageverifyd | [outerheaven199X/ageverifyd](https://github.com/outerheaven199X/ageverifyd) | [README](https://github.com/outerheaven199X/ageverifyd) | active implementation | Standalone daemon implementing the proposed Linux age-verification D-Bus model | Provides reusable plumbing for normalization of age-signaling across Linux distributions and app ecosystems |
 
 #### Distribution / desktop-specific integrations
 
@@ -49,6 +48,27 @@ The tracker uses the following labels.
 | elementary settings-useraccounts | [elementary/settings-useraccounts](https://github.com/elementary/settings-useraccounts) | [PR #270](https://github.com/elementary/settings-useraccounts/pull/270) | draft | Implements age declaration UI in a desktop account-management component | Demonstrates distro/desktop integration of age declaration concepts |
 | elementary portals | [elementary/portals](https://github.com/elementary/portals) | [Issue #173](https://github.com/elementary/portals/issues/173) | discussion | Proposes account portal work in a user-information exposure layer | Creates a portal-level integration point in elementary OS |
 | elementary portals | [elementary/portals](https://github.com/elementary/portals) | [PR #180](https://github.com/elementary/portals/pull/180) | active implementation | Open multi-commit implementation of the account portal linked to issue #173 | Shows live portal-layer work in a desktop-specific integration path |
+
+### Prototype / reference implementations
+
+| Component | Repository | Item | Status | Why it matters | Downstream implications |
+| --- | --- | --- | --- | --- | --- |
+| ageverifyd | [outerheaven199X/ageverifyd](https://github.com/outerheaven199X/ageverifyd) | [README](https://github.com/outerheaven199X/ageverifyd) | active implementation | Standalone daemon implementing the proposed Linux `org.freedesktop.AgeVerification1` D-Bus model | Provides reusable plumbing for normalization of age-signaling across Linux distributions and app ecosystems, lowering the barrier to adoption |
+
+### BSD / Unix-like integrations
+
+| Component | Repository | Item | Status | Why it matters | Downstream implications |
+| --- | --- | --- | --- | --- | --- |
+| MidnightBSD | [MidnightBSD Draft](https://docs.google.com/document/d/1_NKq0bpN1pOrMpHePuilJY7saXqXqhss6LwPTC6nSto/edit) | [Mailing list post](https://lists.freedesktop.org/archives/xdg/2026-March/014777.html) | active implementation | Explicit BSD-side implementation path for age/DOB storage, installer (`bsdinstall`) and user creation (`adduser`) integration, helper tools (`aged`, `agectl`), and package manager (`mport`) / ACL-based access control | Proves the surveillance architecture is spreading beyond the Linux ecosystem into other free Unix-like operating systems |
+
+### Interface / discussion artifacts
+
+| Source | Item | Status | Why it matters | Downstream implications |
+| --- | --- | --- | --- | --- |
+| freedesktop.org | [xdg-list `AgeVerification1` proposal](https://lists.freedesktop.org/archives/xdg/2026-March/014765.html) | discussion | The primary proposal artifact for the `org.freedesktop.AgeVerification1` D-Bus interface | Represents the starting point for the D-Bus/portal implementation vector |
+| freedesktop.org | [Age Assurance Key Considerations](https://lists.freedesktop.org/archives/xdg/2026-March/014794.html) | discussion | Explores legal and technical contradictions around age-bracket storage, jurisdiction handling, and the practical consequences of conflicting state requirements | Shows the implementation discussion expanding beyond interface shape into jurisdiction logic, data-retention questions, and operational compliance assumptions |
+| freedesktop.org | [File-based protocol proposal](https://lists.freedesktop.org/archives/xdg/2026-March/014802.html) | discussion | Proposes a file/filesystem-based age attestation model as a more secure alternative to D-Bus | Shows the design space has expanded to include non-D-Bus, anti-circumvention-focused models |
+| freedesktop.org | [LSM / xattr implementation proposal](https://lists.freedesktop.org/archives/xdg/2026-March/014779.html) | discussion | Proposes using Linux Security Modules and extended attributes for enforcement | Indicates the problem is expanding to kernel-level and filesystem-level enforcement mechanisms |
 
 ### Policy drivers and legal watchlist
 
@@ -65,7 +85,7 @@ The tracker uses the following labels.
 
 ## Primary tracked sources
 
-### Active Linux implementation targets
+### Implementation targets and proposals
 
 - [systemd PR #40954](https://github.com/systemd/systemd/pull/40954)
 - [systemd Issue #40974](https://github.com/systemd/systemd/issues/40974)
@@ -79,7 +99,11 @@ The tracker uses the following labels.
 - [elementary/portals Issue #173](https://github.com/elementary/portals/issues/173)
 - [elementary/portals PR #180](https://github.com/elementary/portals/pull/180)
 - [outerheaven199X/ageverifyd](https://github.com/outerheaven199X/ageverifyd)
-
+- [MidnightBSD Age Verification Draft](https://docs.google.com/document/d/1_NKq0bpN1pOrMpHePuilJY7saXqXqhss6LwPTC6nSto/edit)
+- [freedesktop.org `AgeVerification1` proposal thread](https://lists.freedesktop.org/archives/xdg/2026-March/014765.html)
+- [freedesktop.org Age Assurance Key Considerations thread](https://lists.freedesktop.org/archives/xdg/2026-March/014794.html)
+- [freedesktop.org File-based proposal thread](https://lists.freedesktop.org/archives/xdg/2026-March/014802.html)
+- [freedesktop.org LSM / xattr proposal thread](https://lists.freedesktop.org/archives/xdg/2026-March/014779.html)
 
 ### Policy drivers and legal watchlist
 


### PR DESCRIPTION
Restructures the project's documentation to accurately track the expanding scope of OS-level age verification. The evidence base now shows the threat is no longer a single Linux API proposal but a multi-front implementation effort across different architectures and operating systems.

The core trackers (`TRACKER.md`, `REPO-TARGETS.md`) are reorganized to explicitly categorize targets by ecosystem:
- Linux (shared infrastructure and distro-specific)
- BSD / Unix-like
- Standalone Prototypes

This change adds MidnightBSD as a first-class tracked target, documenting its implementation path for age verification via `bsdinstall`, `adduser`, helper tools, and package manager integration. It also adds key discussion artifacts from the freedesktop.org mailing lists, capturing competing proposals for file-based attestation and LSM/xattr enforcement.

Finally, the architectural map (`STACK.md`) is updated to reflect these newly visible vectors, providing a more complete model of how surveillance mechanisms can propagate through a system.