### PR TITLE
docs: add ACTORS.md to track policy and advocacy ecosystem (#16)

### DIFF
--- a/ACTORS.md
+++ b/ACTORS.md
@@ -1,0 +1,67 @@
+# Actors and Policy Ecosystem
+
+Back to the front page: [README.md](README.md)
+
+## Purpose
+
+This document records the organizations, model-bill producers, advocacy groups, and public-support ecosystem behind OS-level age verification laws and related app-store mandates. It exists to document the policy-production layer that shapes the legal and technical landscape this project tracks.
+
+For legal texts, see [LAWS.md](LAWS.md). For technical implementation status, see [TRACKER.md](TRACKER.md).
+
+## Why this file exists
+
+The legal text and technical implementation of surveillance mechanisms do not arise in a vacuum. They are often preceded by model legislation, technical whitepapers, and coordinated advocacy. This document provides a dedicated, evidence-based home for that context, ensuring that `LAWS.md` can remain focused on final legal text and `TRACKER.md` on technical artifacts.
+
+Documenting this layer is critical to understanding how a policy idea is developed, standardized, and promoted before it becomes law.
+
+## Core actors and ecosystem
+
+### International Centre for Missing & Exploited Children (ICMEC)
+
+ICMEC is a key actor in the production of model legislation for OS-level age verification. The organization has publicly hosted a policy and technical toolkit for a model called the "Digital Age Assurance Act."
+
+This toolkit includes:
+
+- A [model bill](https://cdn.icmec.org/wp-content/uploads/2024/10/Digital-Age-Assurance-Act-2024.pdf) proposing a standardized legal framework for states.
+- A [technical whitepaper](https://cdn.icmec.org/wp-content/uploads/2024/10/Digital-Age-Assurance-Act-Technical-Whitepaper-FINAL-Feb-07-2025.pdf) that advocates for device-based age assurance, where the operating system verifies a user's age once, stores it locally, and provides an age-bracket signal to applications via an API.
+- A [constitutional analysis](https://cdn.icmec.org/wp-content/uploads/2024/10/The-Digital-Age-Assurance-Act-Constitutional-Analysis-02-07-2025-FINAL.docx.pdf) intended to defend the model against legal challenges.
+
+This work matters because it provides direct evidence that the OS-level model being implemented in laws like California's AB 1043 is not an isolated improvisation, but part of a pre-existing, reusable policy and technical template.
+
+### California AB 1043 support ecosystem
+
+California's enacted AB 1043, which requires OS providers and app stores to provide an age-signal mechanism, received public support from major technology companies.
+
+According to a [press release](https://a14.asmdc.org/press-releases/20250909-google-meta-among-tech-leaders-and-child-advocates-voicing-support-wicks) from bill author Assemblymember Buffy Wicks, the following companies voiced support for the bill:
+
+- Google
+- Meta
+- Snap
+- OpenAI
+
+This matters because it confirms that major platform actors, including those this project tracks in other contexts, publicly endorsed the OS-level signal model in California, lending significant weight to its passage and normalization. The [enacted bill text](https://leginfo.legislature.ca.gov/faces/billVersionsCompareClient.xhtml?bill_id=202520260AB1043) aligns with this model, requiring an interface for users to provide their birth date or age and for applications to request a "signal" from the OS or app store.
+
+### Template ecosystem context
+
+While this project focuses on verifiable primary sources, it is important to note the broader context of competing and complementary legislative templates. Evidence suggests at least two distinct models are being promoted in U.S. states:
+
+1.  **OS-layer mandates** (e.g., California AB 1043), which place the implementation burden on operating system providers.
+2.  **App-store mandates** (e.g., Texas SB 2420), which place the burden on app store providers like Apple and Google.
+
+The Texas app-store law was [preliminarily blocked by a federal court](https://www.reuters.com/legal/government/us-judge-blocks-texas-app-store-age-law-meant-protect-children-2025-12-23/) before taking effect, showing that legal outcomes are not uniform across different template families. This project tracks both models because they are part of the same overall push toward age-verification infrastructure.
+
+## Research leads requiring further verification
+
+This section contains claims and synthesis from publicly available analysis that require further independent, primary-source verification before being promoted into core dossier claims.
+
+- The existence of a coordinated, two-template legislative strategy funded by distinct actors with specific financial motivations (e.g., COPPA liability shifting).
+- The full funding sources and organizational relationships behind advocacy coalitions like the Digital Childhood Alliance.
+
+These are treated as research hypotheses, not verified facts, until supported by direct evidence such as financial disclosures, lobbying records, or official documents.
+
+## See also
+
+- [README.md](README.md)
+- [LAWS.md](LAWS.md)
+- [TRACKER.md](TRACKER.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Use the document that matches the content.
 
 - Add implementation evidence, issues, pull requests, merge requests, and status updates to [TRACKER.md](TRACKER.md).
 - Add legal and policy background to [LAWS.md](LAWS.md).
+- Add model bills, advocacy groups, and public endorsements to [ACTORS.md](ACTORS.md).
 - Add architecture relationships and propagation paths to [STACK.md](STACK.md).
 - Add component-specific technical detail to [REPO-TARGETS.md](REPO-TARGETS.md).
 - Add removal and stripping notes to [REVERSIONS/README.md](REVERSIONS/README.md).
@@ -36,6 +37,16 @@ Every contribution should be:
 - scoped to the project mission
 - placed in the correct file
 - written in consistent terminology
+
+### Evidence quality and source distinctions
+
+This project maintains a strict distinction between different types of claims. When contributing, especially to [ACTORS.md](ACTORS.md), classify your evidence correctly:
+
+- **Primary-source facts:** Claims directly supported by primary sources such as official bill text, press releases from involved parties, court filings, or technical whitepapers published by the source organization. These are suitable for core dossier entries.
+- **Cross-source synthesis:** Claims that connect multiple primary-source facts to form a larger conclusion (e.g., "Template A and Template B are complementary"). These should be presented carefully, with all underlying sources cited, and must avoid making unsubstantiated leaps of logic.
+- **Inference and interpretation:** Claims about motive, intent, or unstated strategy (e.g., "Company X funded this to avoid Y liability"). These are high-risk claims and are not suitable for core dossier entries. They should be proposed as "research leads" and must be explicitly labeled as requiring further verification.
+
+The goal is to build a credible, auditable dossier. Stick to what can be directly verified from high-quality sources.
 
 ## Required evidence quality
 
@@ -162,4 +173,5 @@ Use high-quality Markdown. Keep headings clean, lists consistent, and prose prec
 - [LAWS.md](LAWS.md)
 - [STACK.md](STACK.md)
 - [REPO-TARGETS.md](REPO-TARGETS.md)
+- [ACTORS.md](ACTORS.md)
 - [REVERSIONS/README.md](REVERSIONS/README.md)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Start here, then use the following documents for specific purposes:
 - [LAWS.md](LAWS.md): legal and policy drivers
 - [STACK.md](STACK.md): technical architecture and propagation path
 - [REPO-TARGETS.md](REPO-TARGETS.md): component-by-component technical targets
+- [ACTORS.md](ACTORS.md): model-bill producers, advocacy ecosystem, and public-support map
 - [REVERSIONS/README.md](REVERSIONS/README.md): removal, stripping, and reversal strategy
 - [CONTRIBUTING.md](CONTRIBUTING.md): contribution standards and evidence rules
 
@@ -185,4 +186,4 @@ Free software distributions must not be turned into surveillance infrastructure.
 
 OSS Anti Surveillance exists to document these mechanisms, track their spread, oppose their normalization, and prepare their removal where necessary. This project's repository is a public record, a technical map, and a practical starting point for reversal work.
 
-See also: [MANIFESTO.md](MANIFESTO.md), [TRACKER.md](TRACKER.md), [LAWS.md](LAWS.md), [STACK.md](STACK.md), [REPO-TARGETS.md](REPO-TARGETS.md), [REVERSIONS/README.md](REVERSIONS/README.md), [CONTRIBUTING.md](CONTRIBUTING.md)
+See also: [MANIFESTO.md](MANIFESTO.md), [TRACKER.md](TRACKER.md), [LAWS.md](LAWS.md), [STACK.md](STACK.md), [REPO-TARGETS.md](REPO-TARGETS.md), [ACTORS.md](ACTORS.md), [REVERSIONS/README.md](REVERSIONS/README.md), [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/tools/audit_docs.py
+++ b/tools/audit_docs.py
@@ -22,6 +22,7 @@ CANONICAL_FILES = [
     "REPO-TARGETS.md",
     "CONTRIBUTING.md",
     "REVERSIONS/README.md",
+    "ACTORS.md",
 ]
 
 README_REQUIRED_LINKS = [
@@ -33,6 +34,7 @@ README_REQUIRED_LINKS = [
     "REPO-TARGETS.md",
     "REVERSIONS/README.md",
     "CONTRIBUTING.md",
+    "ACTORS.md",
 ]
 
 REQUIRED_SECTIONS = {
@@ -53,7 +55,7 @@ REQUIRED_SECTIONS = {
     ],
     "LAWS.md": [
         "Purpose",
-        "Current legal and policy drivers",
+        "U.S. state landscape",
     ],
     "STACK.md": [
         "Purpose",
@@ -71,6 +73,11 @@ REQUIRED_SECTIONS = {
     "REVERSIONS/README.md": [
         "Purpose",
         "Current strategy",
+    ],
+    "ACTORS.md": [
+        "Purpose",
+        "Why this file exists",
+        "Core actors and ecosystem",
     ],
 }
 


### PR DESCRIPTION
Introduces a new canonical document, `ACTORS.md`, to serve as an evidence-based map of the policy-production and advocacy ecosystem behind OS-level age verification laws. This file will document organizations that draft model bills, publish technical justifications, and publicly endorse surveillance mechanisms.

This change fills a previously identified architectural gap, providing a dedicated home for this distinct class of information. This strengthens the project's analytical depth and upholds the principle of sharp document roles by preventing `LAWS.md` from becoming overloaded with non-legal context.

To support this addition, the following integrations were made:
- `README.md` was updated to include `ACTORS.md` in the repository map.
- `CONTRIBUTING.md` was updated with standards for actor-related evidence, distinguishing between primary sources and synthesis.
- The audit script `tools/audit_docs.py` was updated to recognize `ACTORS.md` as a canonical file and validate its structure.