### PR TITLE
docs: record closed systemd birthDate revert attempt (#26)

### DIFF
--- a/REPO-TARGETS.md
+++ b/REPO-TARGETS.md
@@ -24,6 +24,9 @@ Current upstream references:
 
 - [PR #40954](https://github.com/systemd/systemd/pull/40954)
 - [Issue #40974](https://github.com/systemd/systemd/issues/40974)
+- [PR #41179](https://github.com/systemd/systemd/pull/41179)
+
+A direct upstream revert attempt was later submitted as PR #41179 and closed. In that discussion, maintainers defended the merged `birthDate` field as optional schema standardization rather than a policy engine. This is relevant because it makes the current upstream posture explicit and clarifies the rationale that critics of the field must now address.
 
 #### xdg-desktop-portal
 

--- a/REVERSIONS/systemd/README.md
+++ b/REVERSIONS/systemd/README.md
@@ -12,6 +12,10 @@ This document explains the reversal path for the upstream systemd change that ad
 - **Merge Commit:** [`acb6624fa19ddd68f9433fb0838db119fe18c3ed`](https://github.com/systemd/systemd/commit/acb6624fa19ddd68f9433fb0838db119fe18c3ed)
 - **Context:** This merge introduced age-related fields into the core `systemd` userdb layer, crossing a defined project red line by formalizing a storage substrate for OS-level age signaling.
 
+## Closed upstream revert attempt
+
+A direct upstream revert attempt was submitted as PR #41179 and later closed. In the discussion, the merged `birthDate` field was defended by maintainers as an optional schema field rather than a policy engine. This matters because it makes the current upstream rationale explicit and clarifies the argument that critics of the field must now confront.
+
 ## Canonical upstream revert command
 
 Because the target is a merge commit (combining two parent commits into the mainline), the canonical command requires the `-m 1` flag. Parent 1 represents the pre-merge mainline.

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -34,6 +34,7 @@ The tracker uses the following labels.
 | --- | --- | --- | --- | --- | --- |
 | systemd | [systemd/systemd](https://github.com/systemd/systemd) | [PR #40954](https://github.com/systemd/systemd/pull/40954) | merged | Adds `birthDate` to JSON user records; the storage substrate is no longer hypothetical and has merged upstream | Creates an upstream identity-data substrate that downstreams may inherit unless actively stripped; raises urgency for containment and increases risk of follow-on consumption |
 | systemd | [systemd/systemd](https://github.com/systemd/systemd) | [Issue #40974](https://github.com/systemd/systemd/issues/40974) | closed unmerged | Closed as not planned; maintainers indicated birthDate remains preferred and ageGroup should live elsewhere via a service | Rejects one schema variant in systemd userdb, but leaves the broader service-based age-verification path open |
+| systemd | [systemd/systemd](https://github.com/systemd/systemd) | [PR #41179](https://github.com/systemd/systemd/pull/41179) | closed unmerged | Direct upstream attempt to revert the merged `birthDate` field. The maintainer response explicitly defended the change as an optional schema field rather than a policy engine, making the current upstream rationale explicit. | Clarifies the upstream position that critics and downstream packagers must now rebut if they oppose the field’s continued normalization and spread. |
 | xdg-desktop-portal | [flatpak/xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal) | [PR #1922](https://github.com/flatpak/xdg-desktop-portal/pull/1922) | draft | App-facing portal/API normalization point for age-related querying | Makes the mechanism easier to standardize across desktop environments and applications |
 | AccountsService | [accountsservice/accountsservice](https://gitlab.freedesktop.org/accountsservice/accountsservice) | [MR !176](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176) | discussion | Referenced by related work as a storage and D-Bus layer for `BirthDate` | Represents a likely account metadata layer in the wider stack |
 
@@ -89,6 +90,7 @@ The tracker uses the following labels.
 
 - [systemd PR #40954](https://github.com/systemd/systemd/pull/40954)
 - [systemd Issue #40974](https://github.com/systemd/systemd/issues/40974)
+- [systemd PR #41179](https://github.com/systemd/systemd/pull/41179)
 - [xdg-desktop-portal PR #1922](https://github.com/flatpak/xdg-desktop-portal/pull/1922)
 - [ubuntu-desktop-provision PR #1338](https://github.com/canonical/ubuntu-desktop-provision/pull/1338)
 - [ubuntu-desktop-provision PR #1339](https://github.com/canonical/ubuntu-desktop-provision/pull/1339)


### PR DESCRIPTION
This change updates the project's documentation to accurately reflect the current upstream posture regarding the `birthDate` field in systemd user records.

A new entry has been added to TRACKER.md for systemd PR #41179, a direct attempt to revert the original change. This entry records the PR's closure and summarizes the maintainer's defense of the field as an optional schema standardization rather than a policy engine.

Corresponding context has been added to REPO-TARGETS.md and REVERSIONS/systemd/README.md. This ensures that downstream packagers and critics have a complete and accurate view of the upstream situation, including the specific rationale that must be addressed when arguing against the field's normalization.