### PR TITLE
docs: refine TBOTE external research references (#28)

### DIFF
--- a/ACTORS.md
+++ b/ACTORS.md
@@ -69,12 +69,14 @@ This matters because it confirms opposition is not merely political or activist,
 
 ## Related external research
 
-This project is aware of external investigations into the policy and lobbying ecosystem surrounding these legislative efforts. The TBOTE Project, for example, provides deep-dive research into lobbying records, funding structures, and actor relationships.
+This project is aware of external investigations into the policy and lobbying ecosystem surrounding these legislative efforts. The TBOTE Project is one such external research effort. It now provides not only a research repository, but also public findings and verification-oriented materials.
 
 - **TBOTE Project Home:** `https://tboteproject.com/`
 - **TBOTE Research Repository:** `https://tboteproject.com/git/hekate/attestation-findings`
+- **TBOTE Findings:** `https://tboteproject.com/findings/`
+- **TBOTE Verify:** `https://tboteproject.com/verify/`
 
-OSS Anti Surveillance may use such projects for discovery and contextual analysis, but will continue to anchor its own core dossier claims in direct legal, technical, and primary-source evidence, per the project's contribution standards.
+OSS Anti Surveillance may use such projects for discovery, contextual analysis, and research leads, but continues to anchor its own core dossier claims in direct legal, technical, and primary-source evidence, per the project's contribution standards.
 
 ## Research leads requiring further verification
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Start here, then use the following documents for specific purposes:
 - [LAWS.md](LAWS.md): legal and policy drivers
 - [STACK.md](STACK.md): technical architecture and propagation path
 - [REPO-TARGETS.md](REPO-TARGETS.md): component-by-component technical targets
-- [ACTORS.md](ACTORS.md): model-bill producers, advocacy ecosystem, and public-support map
+- [ACTORS.md](ACTORS.md): policy ecosystem, actor map, and related external research
 - [REVERSIONS/README.md](REVERSIONS/README.md): removal, stripping, and reversal strategy
 - [CONTRIBUTING.md](CONTRIBUTING.md): contribution standards and evidence rules
 


### PR DESCRIPTION
Refine the reference to the TBOTE Project in `ACTORS.md` to provide a more comprehensive and useful set of links to its public-facing research materials.

This change updates the link list to include the project's dedicated "Findings" and "Verify" pages, making it easier for users to access its structured analysis and reproducibility workflows. The surrounding prose is updated to better frame the role of this external research as a source for discovery and context, while reaffirming that this project's core claims remain anchored in primary-source evidence.

The `README.md` repository map is also updated to more accurately describe the role of `ACTORS.md`, clarifying that it includes a map of related external research.