### PR TITLE
docs: track MidnightBSD aged merge and add untested reversal guide (#38)

### DIFF
--- a/REPO-TARGETS.md
+++ b/REPO-TARGETS.md
@@ -121,18 +121,19 @@ Current upstream references:
 
 ### BSD / Unix-like integration targets
 
-#### MidnightBSD age verification
+#### MidnightBSD age verification (`aged`)
 
-Repository: [MidnightBSD Project](https://www.midnightbsd.org/)
+Repository: [MidnightBSD/src](https://github.com/MidnightBSD/src)
 
-Role in the stack: This work represents a complete, parallel implementation of an OS-level age verification architecture for a BSD-based operating system. It includes installer (`bsdinstall`) and user management (`adduser`) integration, dedicated helper tools (`aged`, `agectl`), and enforcement paths via the package manager (`mport`) and ACLs.
+Role in the stack: This is a merged, base-system implementation of an OS-level age verification architecture for a BSD-based operating system. It includes a standalone daemon (`aged`), an admin tool (`agectl`), per-user age/DOB storage, a Unix socket for queries, and `rc` startup integration.
 
-Why it matters: This is critical evidence that the surveillance architecture is not a Linux-specific problem. It is a pattern spreading to other free Unix-like operating systems, using native system administration tools and concepts.
+Why it matters: This is critical evidence that the surveillance architecture is not a Linux-specific problem but a pattern spreading to other free Unix-like operating systems. Unlike discussion drafts, this is a merged upstream artifact. Post-merge commits have expanded the subsystem to include age-based group membership changes, showing a drift from passive signaling toward active policy enforcement.
 
 Current upstream references:
 
-- [Implementation Draft](https://docs.google.com/document/d/1_NKq0bpN1pOrMpHePuilJY7saXqXqhss6LwPTC6nSto/edit)
-- [Mailing list discussion](https://lists.freedesktop.org/archives/xdg/2026-March/014777.html)
+- [PR #302](https://github.com/MidnightBSD/src/pull/302) (Initial merge)
+- [`usr.sbin/aged` commit history](https://github.com/MidnightBSD/src/commits/master/usr.sbin/aged) (Post-merge expansion)
+- [Historical design draft](https://docs.google.com/document/d/1_NKq0bpN1pOrMpHePuilJY7saXqXqhss6LwPTC6nSto/edit)
 
 ## Watchlist concept
 

--- a/REVERSIONS/README.md
+++ b/REVERSIONS/README.md
@@ -72,6 +72,7 @@ As the project grows, this directory contains component-specific reversal notes 
 
 Currently active reversal documentation:
 - [systemd: revert `birthDate` userdb merge](systemd/README.md)
+- [MidnightBSD: untested guide to remove the merged `aged` subsystem](midnightbsd/README.md)
 
 ## Current status
 

--- a/REVERSIONS/midnightbsd/README.md
+++ b/REVERSIONS/midnightbsd/README.md
@@ -1,0 +1,89 @@
+# MidnightBSD: Untested Guide to Remove the `aged` Subsystem
+
+Back to Reversions index: [README.md](../README.md)
+
+## Purpose
+
+This document records a theoretical downstream rollback path for the merged MidnightBSD `aged` subsystem. It exists because the upstream merge is a high-signal event demonstrating the spread of surveillance architecture to non-Linux free operating systems.
+
+The instructions herein are an **untested theoretical guide** derived from upstream commit history. They have **not been validated** against a live MidnightBSD build and should not be represented as a verified, working procedure.
+
+## Evidence Basis
+
+The `aged` subsystem was merged into the MidnightBSD `master` branch on 9 March 2026. This introduced a daemon, a control utility, per-user age/DOB storage, and base-system integration. Post-merge commits later expanded the subsystem with default assumptions for system accounts and logic for age-based group membership, showing a drift toward policy enforcement.
+
+- **Initial Subsystem Merge:** [MidnightBSD/src#302](https://github.com/MidnightBSD/src/pull/302)
+- **Post-Merge Expansion:** [`usr.sbin/aged` commit history](https://github.com/MidnightBSD/src/commits/master/usr.sbin/aged)
+
+This guide documents what can be inferred from that public history, not a certified build result.
+
+## Untested Theoretical Guidance
+
+The following steps are an **untested theoretical guide**. They are provided to give downstream maintainers and developers a starting point for a proper revert. They may require significant adjustment to account for ancillary files outside `usr.sbin/aged`, build system integration, `rc` scripts, and manpages. This guide is not a substitute for careful, build-verified testing.
+
+## Scope of Rollback: Substrate vs. Escalation
+
+A clean removal should distinguish between two layers of changes, each with a distinct architectural role.
+
+### 1. Post-Merge Escalation Commits
+
+These commits introduced enforcement-oriented logic after the initial subsystem was merged. Reverting them first represents an immediate containment strategy that strips the most aggressive behavior.
+
+- `0cacaff` — Assume 18+ for root user if undefined.
+- `b1cdf99` — Set a default of 18+ for service accounts.
+- `b883117` — Add/remove users from groups based on age.
+- `15790a1` — Move group-membership logic into `agectl` as `aged` does not run as root.
+
+### 2. Initial Merged Substrate
+
+These commits represent the core `aged` subsystem introduced in PR #302.
+
+- `6e4e5df` — `Create an age verification daemon called aged to query and store age verification data. (#302)`
+- `7da7413` — `Use syslog logging for aged(8) (#304)`
+
+A full rollback would need to revert this set, along with any related changes to build files, `rc` scripts, or manpages included in the original PR.
+
+## Untested Rollback Strategy
+
+A two-tier rollback model is recommended.
+
+### Tier A: Immediate Containment (Lower Risk)
+
+First, revert the post-merge escalation commits. This removes the policy-enforcement layer while leaving the storage/query substrate in place, providing a smaller and likely safer initial patch.
+
+```bash
+# UNTESTED - FOR GUIDANCE ONLY
+git revert 15790a1 b883117 b1cdf99 0cacaff
+```
+
+### Tier B: Full Subsystem Removal (Higher Risk)
+
+After containing the enforcement logic, a full removal would target the initial substrate. Due to the nature of the multi-commit merge in PR #302, a simple revert of one commit may be insufficient. A careful analysis of the PR's full commit set and file changes is required to create a clean revert patch.
+
+The PR's file list includes changes in:
+- `etc/rc.d/`
+- `lib/libc/`
+- `man/`
+- `sbin/`
+- `share/`
+- `usr.sbin/`
+
+A full removal requires reversing changes across all these areas.
+
+## Capability-Based Validation Checklist
+
+A successful rollback should be verified by capability removal, not merely by a successful `git revert` command. After applying any patches, confirm that:
+
+- [ ] The `aged` daemon is no longer built or started at boot.
+- [ ] The `agectl` utility is no longer built or installed.
+- [ ] The `/var/run/aged/aged.sock` Unix socket is no longer created.
+- [ ] The `/var/db/aged/aged.db` SQLite database is no longer created or used.
+- [ ] No user-facing or programmatic interface for setting or querying age/DOB remains.
+- [ ] No age-based group membership logic is present in the system.
+- [ ] The `aged` `rc` script and manpages have been removed.
+
+## Known Uncertainties
+
+- This rollback path is incomplete until validated on a live MidnightBSD source tree.
+- The exact set of commits to revert for a full subsystem removal may be more complex than listed here.
+- This guide is included because the upstream signal is high, not because the platform is strategically central. Further refinement depends on community members performing and reporting a verified revert and build test.

--- a/STACK.md
+++ b/STACK.md
@@ -16,10 +16,10 @@ The key architectural layers and proposed vectors now include:
 
 - **Installer / Account-creation flow:** The point of initial data collection (e.g., `bsdinstall`, `Archinstall`, Ubuntu provisioning).
 - **Account metadata and client-library exposure:** The persistence layer and D-Bus retrieval/mutation service for user age or date of birth (e.g., systemd userdb, AccountsService with `libaccountsservice` exposure, or custom `/etc` files).
-- **Daemon / Helper layer:** Standalone services for managing and exposing age data (e.g., `ageverifyd`, `aged`).
+- **Daemon / Helper layer:** Standalone services for managing and exposing age data (e.g., `ageverifyd` on Linux, `aged` on MidnightBSD).
 - **Portal / D-Bus / API:** The application-facing interface for querying age status (e.g., `xdg-desktop-portal`).
 - **Package manager / Repository integration:** Using the package manager to gate access to software based on age ratings (e.g., MidnightBSD `mport` proposal).
-- **Filesystem / ACL / LSM enforcement:** Lower-level proposals for enforcing access control based on age, using mechanisms like extended attributes (xattrs), Access Control Lists (ACLs), or Linux Security Modules (LSMs).
+- **Filesystem / ACL / LSM enforcement:** Lower-level proposals for enforcing access control based on age, using mechanisms like extended attributes (xattrs), Access Control Lists (ACLs), or Linux Security Modules (LSMs). Post-merge commits to MidnightBSD's `aged` subsystem have also introduced logic for age-based group membership changes, demonstrating a concrete move in this enforcement-oriented direction.
 - **File-based attestation:** Proposals for using root-owned files on the filesystem to signal age brackets, as an alternative to a D-Bus service.
 
 This path matters because it shows the problem is not a single API but a system-wide architectural shift being explored across multiple components and operating systems.

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -60,7 +60,8 @@ The tracker uses the following labels.
 
 | Component | Repository | Item | Status | Why it matters | Downstream implications |
 | --- | --- | --- | --- | --- | --- |
-| MidnightBSD | [MidnightBSD Draft](https://docs.google.com/document/d/1_NKq0bpN1pOrMpHePuilJY7saXqXqhss6LwPTC6nSto/edit) | [Mailing list post](https://lists.freedesktop.org/archives/xdg/2026-March/014777.html) | active implementation | Explicit BSD-side implementation path for age/DOB storage, installer (`bsdinstall`) and user creation (`adduser`) integration, helper tools (`aged`, `agectl`), and package manager (`mport`) / ACL-based access control | Proves the surveillance architecture is spreading beyond the Linux ecosystem into other free Unix-like operating systems |
+| MidnightBSD `aged` | [MidnightBSD/src](https://github.com/MidnightBSD/src) | [PR #302](https://github.com/MidnightBSD/src/pull/302) | merged | Merged a full daemon/helper substrate for age/DOB storage and age-range signaling into the base OS, including `aged`, `agectl`, and rc startup integration. | Proves the surveillance architecture is not Linux-only; introduces a reusable OS-layer classification mechanism into a free Unix-like system. |
+| MidnightBSD `aged` | [MidnightBSD/src](https://github.com/MidnightBSD/src) | [`usr.sbin/aged` commits](https://github.com/MidnightBSD/src/commits/master/usr.sbin/aged) | active implementation | Post-merge commits add default adult assumptions for root/service accounts and age-based group membership logic, escalating from passive storage to active policy enforcement. | Expands the mechanism from signaling toward permission/group-policy effects, demonstrating architectural drift toward system-level access control. |
 
 ### Interface / discussion artifacts
 
@@ -102,7 +103,8 @@ The tracker uses the following labels.
 - [elementary/portals Issue #173](https://github.com/elementary/portals/issues/173)
 - [elementary/portals PR #180](https://github.com/elementary/portals/pull/180)
 - [outerheaven199X/ageverifyd](https://github.com/outerheaven199X/ageverifyd)
-- [MidnightBSD Age Verification Draft](https://docs.google.com/document/d/1_NKq0bpN1pOrMpHePuilJY7saXqXqhss6LwPTC6nSto/edit)
+- [MidnightBSD PR #302 (aged)](https://github.com/MidnightBSD/src/pull/302)
+- [MidnightBSD `usr.sbin/aged` commit history](https://github.com/MidnightBSD/src/commits/master/usr.sbin/aged)
 - [freedesktop.org `AgeVerification1` proposal thread](https://lists.freedesktop.org/archives/xdg/2026-March/014765.html)
 - [freedesktop.org Age Assurance Key Considerations thread](https://lists.freedesktop.org/archives/xdg/2026-March/014794.html)
 - [freedesktop.org File-based proposal thread](https://lists.freedesktop.org/archives/xdg/2026-March/014802.html)


### PR DESCRIPTION
The dossier's information on the MidnightBSD age-verification mechanism was outdated, framing it as a draft or proposal. This is factually incorrect, as MidnightBSD PR #302 was merged, introducing the `aged` subsystem into the base OS. This constitutes a critical documentation drift.

This commit updates the repository to reflect the new reality:
- `TRACKER.md` is restructured to anchor the evidence to the merged PR #302. A separate entry is added for the post-merge commits that escalated the subsystem toward policy enforcement (i.e., age-based group membership).
- `REPO-TARGETS.md` is updated to describe `aged` as a concrete, merged implementation, shifting its evidence basis from old design documents to the upstream commit history.
- `STACK.md` now uses `aged` as a canonical example of a merged daemon/helper layer in a free Unix-like OS.
- A new document, `REVERSIONS/midnightbsd/README.md`, is added. It provides a theoretical reversal path based on upstream commit history but is explicitly and repeatedly labeled as an untested guide to avoid misrepresenting its readiness.

This ensures the project maintains a credible, evidence-based record of a significant escalation in surveillance architecture.